### PR TITLE
Replace PIL and StringIO by OpenCV

### DIFF
--- a/classify_nsfw.py
+++ b/classify_nsfw.py
@@ -4,18 +4,18 @@ Copyright 2016 Yahoo Inc.
 Licensed under the terms of the 2 clause BSD license. 
 Please see LICENSE file in the project root for terms.
 """
-
 import numpy as np
 import os
 import sys
 import argparse
 import glob
 import time
-from PIL import Image
-from StringIO import StringIO
+#from PIL import Image
+#from StringIO import StringIO
 import caffe
+import cv2
 
-
+'''
 def resize_image(data, sz=(256, 256)):
     """
     Resize image. Please use this resize logic for best results instead of the 
@@ -27,8 +27,10 @@ def resize_image(data, sz=(256, 256)):
     :returns bytearray:
         A byte array with the resized image
     """
-    img_data = str(data)
-    im = Image.open(StringIO(img_data))
+    #img_data = str(data)
+    #im = Image.open(StringIO(data))
+    im0 = cv2.imread(data,1)
+    im = 
     if im.mode != "RGB":
         im = im.convert('RGB')
     imr = im.resize(sz, resample=Image.BILINEAR)
@@ -36,7 +38,7 @@ def resize_image(data, sz=(256, 256)):
     imr.save(fh_im, format='JPEG')
     fh_im.seek(0)
     return bytearray(fh_im.read())
-
+'''
 def caffe_preprocess_and_compute(pimg, caffe_transformer=None, caffe_net=None,
     output_layers=None):
     """
@@ -54,13 +56,14 @@ def caffe_preprocess_and_compute(pimg, caffe_transformer=None, caffe_net=None,
         Returns the requested outputs from the Caffe net.
     """
     if caffe_net is not None:
-
         # Grab the default output names if none were requested specifically.
         if output_layers is None:
             output_layers = caffe_net.outputs
-
-        img_data_rs = resize_image(pimg, sz=(256, 256))
-        image = caffe.io.load_image(StringIO(img_data_rs))
+        #repalce defined resize() by cv2.resize()
+        img_data_rs = cv2.resize(pimg,(256,256))
+        cv2.imwrite('temp.jpg',img_data_rs)
+        #img_data_rs = resize_image(pimg, sz=(256, 256))
+        image = caffe.io.load_image('temp.jpg')
 
         H, W, _ = image.shape
         _, _, h, w = caffe_net.blobs['data'].data.shape
@@ -101,7 +104,7 @@ def main(argv):
     )
 
     args = parser.parse_args()
-    image_data = open(args.input_file).read()
+    image_data = cv2.imread(args.input_file)
 
     # Pre-load caffe model.
     nsfw_net = caffe.Net(args.model_def,  # pylint: disable=invalid-name
@@ -121,8 +124,6 @@ def main(argv):
     # Scores is the array containing SFW / NSFW image probabilities
     # scores[1] indicates the NSFW probability
     print "NSFW score:  " , scores[1]
-
-
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/classify_nsfw.py
+++ b/classify_nsfw.py
@@ -15,30 +15,6 @@ import time
 import caffe
 import cv2
 
-'''
-def resize_image(data, sz=(256, 256)):
-    """
-    Resize image. Please use this resize logic for best results instead of the 
-    caffe, since it was used to generate training dataset 
-    :param str data:
-        The image data
-    :param sz tuple:
-        The resized image dimensions
-    :returns bytearray:
-        A byte array with the resized image
-    """
-    #img_data = str(data)
-    #im = Image.open(StringIO(data))
-    im0 = cv2.imread(data,1)
-    im = 
-    if im.mode != "RGB":
-        im = im.convert('RGB')
-    imr = im.resize(sz, resample=Image.BILINEAR)
-    fh_im = StringIO()
-    imr.save(fh_im, format='JPEG')
-    fh_im.seek(0)
-    return bytearray(fh_im.read())
-'''
 def caffe_preprocess_and_compute(pimg, caffe_transformer=None, caffe_net=None,
     output_layers=None):
     """


### PR DESCRIPTION
My platform is Windows 7 with Python 2.7. There is a bug about StringIO I can not fix, so I replace the StringIO and PIL module by OpenCV. Delete defined resize() function and replace it by cv2.resize(). And use cv2.imread() to read images. It then work well.
